### PR TITLE
Issue 1: Add Build Visitor Counting Interface

### DIFF
--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -74,7 +74,7 @@
           <template v-else>
             <v-text-field
               :max="totalVistorsForDay - categorizedVistorsExceptThoseIn(location)"
-              :modelValue="location.delta"
+              :modelValue="location.daily_total + location.delta"
               @update:modelValue="
                 (newValue) => updateLocationCategoryTotal(location, newValue)
               "
@@ -118,7 +118,8 @@ export default {
   mounted() {
     if (!isEmpty(this.dataEntrySites)) {
       this.loadDailyStats(this.dataEntrySites).then(() => {
-        return this.selectFirstToManage();
+        this.selectFirstToManage();
+        this.totalVistorsForDay = this.uncategorizedVisitors + this.categorizedVistors
       });
     }
   },
@@ -149,11 +150,11 @@ export default {
       );
     },
     uncategorizedVisitors() {
-      return this.uncategorizedLocation.delta;
+      return this.uncategorizedLocation.daily_total + this.uncategorizedLocation.delta;
     },
     categorizedVistors() {
       return this.categorizedLocations.reduce(
-        (total, location) => total + location.delta,
+        (total, location) => total + location.daily_total + location.delta,
         0
       );
     },
@@ -168,7 +169,7 @@ export default {
       this.selectedDate = this.selectedSite.days[0];
     },
     categorizedVistorsExceptThoseIn(excludedLocation) {
-      return this.categorizedVistors - excludedLocation.delta
+      return this.categorizedVistors - excludedLocation.daily_total - excludedLocation.delta
     },
     parseAndNaturalizeNumber(value) {
       return Math.max(0, parseInt(value) || 0)
@@ -180,7 +181,7 @@ export default {
     },
     updateUncategorizedVisitors() {
       this.uncategorizedLocation.delta =
-        this.totalVistorsForDay - this.categorizedVistors;
+        this.totalVistorsForDay - this.categorizedVistors - this.uncategorizedLocation.daily_total;
     },
     updateLocationCategoryTotal(location, value) {
       const normalizedValue = this.parseAndNaturalizeNumber(value)
@@ -188,7 +189,7 @@ export default {
       const maxAvailableVisitors = this.totalVistorsForDay - this.categorizedVistorsExceptThoseIn(location)
       const maxLimitedValule = Math.min(normalizedValue, maxAvailableVisitors)
 
-      location.delta = maxLimitedValule;
+      location.delta = maxLimitedValule - location.daily_total;
       this.updateUncategorizedVisitors();
     },
     updateTotalVistors(value) {

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -126,10 +126,7 @@ export default {
     ...mapState(useCentreStore, ["dateOptions", "manageSites"]),
     ...mapWritableState(useCentreStore, ["selectedDate", "selectedSite"]),
     totalCountHeader() {
-      if (this.totalVistorsForDay > 0) {
-        return `${this.totalVistorsForDay} visitors`;
-      }
-      return "";
+      return `${this.totalVistorsForDay} visitors`;
     },
     dateHeader() {
       if (this.selectedSite && this.selectedDate) {

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -46,7 +46,7 @@
             @update:modelValue="updateTotalVistors"
             type="number"
             min="0"
-            label="Daily Total"
+            label="Total Vistors for Day"
             hide-details
           />
         </v-col>
@@ -55,7 +55,7 @@
         <v-col cols="3">Visitor Origin</v-col>
         <v-col> </v-col>
         <v-col cols="3" class="text-body-1 text-center">
-          Daily Totals by Location
+          Vistors per Location
         </v-col>
       </v-row>
       <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">
@@ -176,9 +176,13 @@ export default {
     selectTodaysDate() {
       this.selectedDate = this.selectedSite.days[0];
     },
+    updateUncategorizedVistors() {
+      this.uncategorizedLocation.daily_total = this.totalVistorsForDay - this.categorizedVistors
+    },
     updateLocationCategoryTotal(location, value) {
-      location.daily_total = parseInt(value);
-      this.uncategorizedLocation.daily_total -= parseInt(value)
+      const valueAsInt = parseInt(value) || 0
+      location.daily_total = valueAsInt;
+      this.updateUncategorizedVistors()
     },
     updateTotalVistors(value) {
       if (value < this.totalVistorsForDay) {
@@ -186,8 +190,8 @@ export default {
         // successively remove 1 from each other category
         // until total vistors is 0
       } else {
-        this.totalVistorsForDay = parseInt(value);
-        this.uncategorizedLocation.daily_total = this.totalVistorsForDay - this.categorizedVistors;
+        this.totalVistorsForDay = parseInt(value) || 0;
+        this.updateUncategorizedVistors()
       }
     },
   },

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -40,7 +40,7 @@
     <div v-if="selectedSite">
       <v-row class="mt-5">
         <v-col></v-col>
-        <v-col cols="3">
+        <v-col md="3">
           <v-text-field
             :modelValue="totalVistorsForDay"
             @update:modelValue="updateTotalVistors"
@@ -52,19 +52,17 @@
         </v-col>
       </v-row>
       <v-row class="mt-5">
-        <v-col cols="3">Visitor Origin</v-col>
-        <v-col> </v-col>
-        <v-col cols="3" class="text-body-1 text-center">
+        <v-col>Visitor Origin</v-col>
+        <v-col md="3">
           Daily Visitors
         </v-col>
       </v-row>
       <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">
         <v-divider></v-divider>
-        <v-col cols="3">
+        <v-col>
           <div class="text-h6 float-left pt-3">{{ location.name }}</div>
         </v-col>
-        <v-col></v-col>
-        <v-col cols="3">
+        <v-col md="3">
           <template v-if="location.name == UNKNOWN_CATEGORY_LOCATION_NAME">
             <v-text-field
               :modelValue="uncategorizedLocation.daily_total"
@@ -95,8 +93,8 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="9"></v-col>
-        <v-col>
+        <v-col></v-col>
+        <v-col sm="6" md="3">
           <v-btn
             color="primary"
             size="large"

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -1,0 +1,186 @@
+<template>
+  <BaseCard showHeader="t" heading="" class="pb-3">
+    <template v-slot:left>
+      <v-select
+        :items="manageSites"
+        label="Site"
+        hide-details
+        v-model="selectedSite"
+        return-object
+        style="max-width: 250px"
+        item-title="name"
+        :disabled="isDirty"
+        @update:modelValue="changed"
+        item-value="id"></v-select>
+    </template>
+
+    <template v-slot:center>
+      <div style="margin-top: 0px; text-align: center">
+        <div style="font-size: 1.5rem; font-weight: bold; line-height: 1.6rem">{{ totalCountHeader }}</div>
+        {{ dateHeader }}
+      </div>
+    </template>
+
+    <template v-slot:right>
+      <v-select
+        v-model="selectedDate"
+        label="Date"
+        :items="dateOptions"
+        item-title="date"
+        return-object
+        hide-details
+        :disabled="isDirty"
+        style="max-width: 250px"></v-select>
+    </template>
+
+    <div v-if="selectedSite">
+      <v-row class="mt-5">
+        <v-col cols="3">Visitor Origin</v-col>
+        <v-col></v-col>
+        <v-col cols="3" class="text-body-1 text-center"> Daily Totals </v-col>
+        <!-- <v-col cols="3" class="text-body-1 text-center"> Weekly Totals </v-col> -->
+      </v-row>
+      <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">
+        <v-divider></v-divider>
+        <v-col cols="3">
+          <div class="text-h6 float-left pt-3">{{ location.name }}</div>
+        </v-col>
+        <v-col>
+          <div class="text-center">
+            <v-btn variant="flat" color="#3A8340" icon="" class="mr-3" @click="plusOne(location)"
+              ><span style="color: white">+1</span></v-btn
+            >
+            <v-btn variant="flat" color="#3A8340" icon="" class="mr-10" @click="plusFive(location)"
+              ><span style="color: white">+5</span></v-btn
+            >
+            <v-btn
+              variant="flat"
+              color="orange"
+              icon=""
+              class="mr-3"
+              @click="minusOne(location)"
+              :disabled="location.daily_total - 1 < 0"
+              >-1</v-btn
+            >
+            <v-btn
+              variant="flat"
+              color="orange"
+              icon=""
+              class="mr-0"
+              @click="minusFive(location)"
+              :disabled="location.daily_total - 5 < 0"
+              >-5</v-btn
+            >
+          </div>
+        </v-col>
+
+        <v-col cols="3" class="text-h6 text-center pt-3">
+          <div class="pt-3">{{ location.daily_total }}</div>
+        </v-col>
+        <!-- <v-col cols="3" class="text-h6 text-center pt-3">
+          <div class="pt-3">{{ location.weekly_total }}</div>
+        </v-col> -->
+      </v-row>
+    </div>
+    <div v-else>Not site selected</div>
+  </BaseCard>
+</template>
+
+<script lang="ts">
+import { mapActions, mapState, mapWritableState } from "pinia";
+import moment from "moment";
+import { useUserStore } from "@/store/UserStore";
+import { useCentreStore } from "../store";
+
+export default {
+  name: "BulkDataEntryCard",
+  components: {},
+  data: () => ({
+    total: 0,
+    isDirty: false,
+  }),
+  async mounted() {
+    //if (this.user.primary_site && this.user.primary_site != -1) this.site = this.user.primary_site;
+    let r = window.setInterval(async () => {
+      if (!this.isDirty) return;
+
+      await this.save();
+      this.isDirty = false;
+    }, 2000);
+
+    if (this.loadFor.length > 0) {
+      await this.loadDailyStats(this.loadFor);
+      this.selectFirstToManage();
+    }
+  },
+  async beforeUnmount() {
+    if (this.selectedDate && this.isDirty) {
+      await this.save();
+    }
+  },
+  computed: {
+    ...mapState(useUserStore, ["user"]),
+    ...mapState(useCentreStore, ["dateOptions", "manageSites"]),
+    ...mapWritableState(useCentreStore, ["selectedDate", "selectedSite"]),
+
+    loadFor() {
+      return this.user.scopes
+        .filter((s: any) => s.name.startsWith("VIC.INPUT"))
+        .map((s: any) => parseInt(s.name.replace("VIC.INPUT_", "")));
+    },
+    totalCountHeader() {
+      if (this.selectedDate && this.selectedDate.origins) {
+        let counts = this.selectedDate.origins.flatMap((i: any) => i.daily_total);
+        let total = counts.reduce((t: number, i: any) => t + i, 0);
+        return `${total} visitors`;
+      }
+      return "";
+    },
+    dateHeader() {
+      if (this.selectedSite && this.selectedDate) {
+        return `${moment(this.selectedDate.date).format("MMMM D, YYYY")} in ${this.selectedSite.name}`;
+      }
+
+      return "";
+    },
+  },
+  methods: {
+    ...mapActions(useUserStore, ["canDo"]),
+    ...mapActions(useCentreStore, ["save", "loadDailyStats", "selectFirstToManage"]),
+
+    changed() {
+      this.selectedDate = (this.selectedSite as any).days[0];
+    },
+
+    plusOne(location: any) {
+      this.isDirty = true;
+      location.delta++;
+    },
+    plusFive(location: any) {
+      this.isDirty = true;
+      location.delta += 5;
+    },
+    minusOne(location: any) {
+      this.isDirty = true;
+      location.delta--;
+    },
+    minusFive(location: any) {
+      this.isDirty = true;
+      location.delta -= 5;
+    },
+  },
+};
+</script>
+
+<style>
+.v-btn.v-btn--disabled.bg-orange {
+  background-color: #895200 !important;
+}
+.v-btn.v-btn--disabled.bg-orange .v-btn__overlay {
+  opacity: 0;
+}
+
+.v-btn.v-btn--disabled.bg-orange .v-btn__content {
+  color: white !important;
+}
+</style>

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -174,7 +174,7 @@ export default {
       return Math.max(0, parseInt(value) || 0)
     },
     saveAndExit() {
-      this.save().then(() => {
+      return this.save().then(() => {
         this.$emit('save')
       })
     },

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -94,6 +94,17 @@
           </template>
         </v-col>
       </v-row>
+      <v-row>
+        <v-col cols="9"></v-col>
+        <v-col>
+          <v-btn
+            color="primary"
+            size="large"
+            block
+            @input="save"
+          >Save</v-btn>
+        </v-col>
+      </v-row>
     </div>
     <div v-else>Not site selected</div>
   </BaseCard>

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -59,7 +59,7 @@
           <div class="text-h6 float-left pt-3">{{ location.name }}</div>
         </v-col>
         <v-col md="3">
-          <template v-if="location.name == UNKNOWN_CATEGORY_LOCATION_NAME">
+          <template v-if="location.id === uncategorizedLocation.id">
             <v-text-field
               :modelValue="uncategorizedVistors"
               density="compact"
@@ -113,7 +113,6 @@ export default {
   components: {},
   data: () => ({
     totalVistorsForDay: 0,
-    UNKNOWN_CATEGORY_LOCATION_NAME,
   }),
   mounted() {
     if (!isEmpty(this.dataEntrySites)) {

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -110,6 +110,7 @@ const UNKNOWN_CATEGORY_LOCATION_NAME = "Unknown";
 
 export default {
   name: "BulkDataEntryCard",
+  emits: ["save"],
   components: {},
   data: () => ({
     totalVistorsForDay: 0,
@@ -174,7 +175,7 @@ export default {
     },
     saveAndExit() {
       this.save().then(() => {
-        this.$emit('saved')
+        this.$emit('save')
       })
     },
     updateUncategorizedVisitors() {

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -61,11 +61,7 @@
         <v-col md="3">
           <template v-if="location.name == UNKNOWN_CATEGORY_LOCATION_NAME">
             <v-text-field
-              :modelValue="uncategorizedLocation.daily_total"
-              @update:modelValue="
-                (newValue) =>
-                  (uncategorizedLocation.daily_total = parseInt(newValue))
-              "
+              :modelValue="uncategorizedVistors"
               density="compact"
               hide-details
               min="0"
@@ -77,7 +73,7 @@
           </template>
           <template v-else>
             <v-text-field
-              :max="uncategorizedVistors"
+              :max="totalVistorsForDay - categorizedVistorsExceptThoseIn(location)"
               :modelValue="location.daily_total"
               @update:modelValue="
                 (newValue) => updateLocationCategoryTotal(location, newValue)
@@ -174,22 +170,32 @@ export default {
     selectTodaysDate() {
       this.selectedDate = this.selectedSite.days[0];
     },
+    categorizedVistorsExceptThoseIn(excludedLocation) {
+      return this.categorizedVistors - excludedLocation.daily_total
+    },
+    parseAndNaturalizeNumber(value) {
+      return Math.max(0, parseInt(value) || 0)
+    },
     updateUncategorizedVistors() {
       this.uncategorizedLocation.daily_total =
         this.totalVistorsForDay - this.categorizedVistors;
     },
     updateLocationCategoryTotal(location, value) {
-      const valueAsInt = parseInt(value) || 0;
-      location.daily_total = valueAsInt;
+      const normalizedValue = this.parseAndNaturalizeNumber(value)
+      location.daily_total = normalizedValue;
       this.updateUncategorizedVistors();
     },
     updateTotalVistors(value) {
-      if (value < this.totalVistorsForDay) {
-        // remove uncategorized unill 0
+      const normalizedValue = this.parseAndNaturalizeNumber(value)
+
+      if (normalizedValue < this.totalVistorsForDay) {
+        this.totalVistorsForDay = normalizedValue;
+        // TODO
+        // remove uncategorized unil 0
         // successively remove 1 from each other category
         // until total vistors is 0
       } else {
-        this.totalVistorsForDay = parseInt(value) || 0;
+        this.totalVistorsForDay = normalizedValue;
         this.updateUncategorizedVistors();
       }
     },

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -55,7 +55,7 @@
         <v-col cols="3">Visitor Origin</v-col>
         <v-col> </v-col>
         <v-col cols="3" class="text-body-1 text-center">
-          Vistors per Location
+          Daily Visitors
         </v-col>
       </v-row>
       <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -194,17 +194,13 @@ export default {
     },
     updateTotalVistors(value) {
       const normalizedValue = this.parseAndNaturalizeNumber(value)
-
       if (normalizedValue < this.totalVistorsForDay) {
-        this.totalVistorsForDay = normalizedValue;
-        // TODO
-        // remove uncategorized unil 0
-        // successively remove 1 from each other category
-        // until total vistors is 0
-      } else {
-        this.totalVistorsForDay = normalizedValue;
-        this.updateUncategorizedVisitors();
+        this.categorizedLocations.forEach(location => {
+          location.delta = -location.daily_total
+        })
       }
+      this.totalVistorsForDay = normalizedValue;
+      this.updateUncategorizedVisitors();
     },
   },
 };

--- a/src/web/src/modules/centre/components/BulkDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/BulkDataEntryCard.vue
@@ -181,7 +181,11 @@ export default {
     },
     updateLocationCategoryTotal(location, value) {
       const normalizedValue = this.parseAndNaturalizeNumber(value)
-      location.daily_total = normalizedValue;
+
+      const maxAvailableVisitors = this.totalVistorsForDay - this.categorizedVistorsExceptThoseIn(location)
+      const maxLimitedValule = Math.min(normalizedValue, maxAvailableVisitors)
+
+      location.daily_total = maxLimitedValule;
       this.updateUncategorizedVistors();
     },
     updateTotalVistors(value) {

--- a/src/web/src/modules/centre/components/DataEntry.vue
+++ b/src/web/src/modules/centre/components/DataEntry.vue
@@ -1,187 +1,45 @@
 <template>
-  <h1 class="text-h5 mb-5">Daily Data Entry</h1>
+  <div class="d-flex justify-space-between">
+    <h1 class="text-h5 mb-5">Daily Data Entry</h1>
 
-  <BaseCard showHeader="t" heading="" class="pb-3">
-    <template v-slot:left>
-      <v-select
-        :items="manageSites"
-        label="Site"
-        hide-details
-        v-model="selectedSite"
-        return-object
-        style="max-width: 250px"
-        item-title="name"
-        :disabled="isDirty"
-        @update:modelValue="changed"
-        item-value="id"></v-select>
-    </template>
-
-    <template v-slot:center>
-      <div style="margin-top: 0px; text-align: center">
-        <div style="font-size: 1.5rem; font-weight: bold; line-height: 1.6rem">{{ totalCountHeader }}</div>
-        {{ dateHeader }}
-      </div>
-    </template>
-
-    <template v-slot:right>
-      <v-select
-        v-model="selectedDate"
-        label="Date"
-        :items="dateOptions"
-        item-title="date"
-        return-object
-        hide-details
-        :disabled="isDirty"
-        style="max-width: 250px"></v-select>
-    </template>
-
-    <div v-if="selectedSite">
-      <v-row class="mt-5">
-        <v-col cols="3">Visitor Origin</v-col>
-        <v-col></v-col>
-        <v-col cols="3" class="text-body-1 text-center"> Daily Totals </v-col>
-        <!-- <v-col cols="3" class="text-body-1 text-center"> Weekly Totals </v-col> -->
-      </v-row>
-      <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">
-        <v-divider></v-divider>
-        <v-col cols="3">
-          <div class="text-h6 float-left pt-3">{{ location.name }}</div>
-        </v-col>
-        <v-col>
-          <div class="text-center">
-            <v-btn variant="flat" color="#3A8340" icon="" class="mr-3" @click="plusOne(location)"
-              ><span style="color: white">+1</span></v-btn
-            >
-            <v-btn variant="flat" color="#3A8340" icon="" class="mr-10" @click="plusFive(location)"
-              ><span style="color: white">+5</span></v-btn
-            >
-            <v-btn
-              variant="flat"
-              color="orange"
-              icon=""
-              class="mr-3"
-              @click="minusOne(location)"
-              :disabled="location.daily_total - 1 < 0"
-              >-1</v-btn
-            >
-            <v-btn
-              variant="flat"
-              color="orange"
-              icon=""
-              class="mr-0"
-              @click="minusFive(location)"
-              :disabled="location.daily_total - 5 < 0"
-              >-5</v-btn
-            >
-          </div>
-        </v-col>
-
-        <v-col cols="3" class="text-h6 text-center pt-3">
-          <div class="pt-3">{{ location.daily_total }}</div>
-        </v-col>
-        <!-- <v-col cols="3" class="text-h6 text-center pt-3">
-          <div class="pt-3">{{ location.weekly_total }}</div>
-        </v-col> -->
-      </v-row>
+    <div>
+      <v-switch
+        v-model="entryMode"
+        label="Direct Input"
+        color="primary"
+        inset
+      ></v-switch>
     </div>
-    <div v-else>Not site selected</div>
-  </BaseCard>
+  </div>
+
+  <template v-if="entryMode">
+    IncrementalDataEntryCard
+    <IncrementalDataEntryCard />
+  </template>
+  <template v-else>
+    BulkDataEntryCard
+    <BulkDataEntryCard />
+  </template>
 </template>
+
 <script lang="ts">
-import { mapActions, mapState, mapWritableState } from "pinia";
-import moment from "moment";
-import { useUserStore } from "@/store/UserStore";
-import { useCentreStore } from "../store";
+import IncrementalDataEntryCard from "./IncrementalDataEntryCard";
+import BulkDataEntryCard from "./BulkDataEntryCard";
 
 export default {
-  name: "Dashboard",
-  components: {},
-  data: () => ({
-    total: 0,
-    isDirty: false,
-  }),
-  async mounted() {
-    //if (this.user.primary_site && this.user.primary_site != -1) this.site = this.user.primary_site;
-    let r = window.setInterval(async () => {
-      if (!this.isDirty) return;
-
-      await this.save();
-      this.isDirty = false;
-    }, 2000);
-
-    if (this.loadFor.length > 0) {
-      await this.loadDailyStats(this.loadFor);
-      this.selectFirstToManage();
+  name: "DataEntry",
+  components: {
+    IncrementalDataEntryCard,
+    BulkDataEntryCard,
+  },
+  data () {
+    return {
+      entryMode: false,
     }
   },
-  async beforeUnmount() {
-    if (this.selectedDate && this.isDirty) {
-      await this.save();
-    }
-  },
-  computed: {
-    ...mapState(useUserStore, ["user"]),
-    ...mapState(useCentreStore, ["dateOptions", "manageSites"]),
-    ...mapWritableState(useCentreStore, ["selectedDate", "selectedSite"]),
-
-    loadFor() {
-      return this.user.scopes
-        .filter((s: any) => s.name.startsWith("VIC.INPUT"))
-        .map((s: any) => parseInt(s.name.replace("VIC.INPUT_", "")));
-    },
-    totalCountHeader() {
-      if (this.selectedDate && this.selectedDate.origins) {
-        let counts = this.selectedDate.origins.flatMap((i: any) => i.daily_total);
-        let total = counts.reduce((t: number, i: any) => t + i, 0);
-        return `${total} visitors`;
-      }
-      return "";
-    },
-    dateHeader() {
-      if (this.selectedSite && this.selectedDate) {
-        return `${moment(this.selectedDate.date).format("MMMM D, YYYY")} in ${this.selectedSite.name}`;
-      }
-
-      return "";
-    },
-  },
-  methods: {
-    ...mapActions(useUserStore, ["canDo"]),
-    ...mapActions(useCentreStore, ["save", "loadDailyStats", "selectFirstToManage"]),
-
-    changed() {
-      this.selectedDate = (this.selectedSite as any).days[0];
-    },
-
-    plusOne(location: any) {
-      this.isDirty = true;
-      location.delta++;
-    },
-    plusFive(location: any) {
-      this.isDirty = true;
-      location.delta += 5;
-    },
-    minusOne(location: any) {
-      this.isDirty = true;
-      location.delta--;
-    },
-    minusFive(location: any) {
-      this.isDirty = true;
-      location.delta -= 5;
-    },
-  },
-};
+}
 </script>
 
-<style>
-.v-btn.v-btn--disabled.bg-orange {
-  background-color: #895200 !important;
-}
-.v-btn.v-btn--disabled.bg-orange .v-btn__overlay {
-  opacity: 0;
-}
+<style scoped>
 
-.v-btn.v-btn--disabled.bg-orange .v-btn__content {
-  color: white !important;
-}
 </style>

--- a/src/web/src/modules/centre/components/DataEntry.vue
+++ b/src/web/src/modules/centre/components/DataEntry.vue
@@ -5,7 +5,7 @@
     <div>
       <v-switch
         v-model="entryMode"
-        label="Direct Input"
+        label="Bulk Input"
         color="primary"
         inset
       ></v-switch>

--- a/src/web/src/modules/centre/components/DataEntry.vue
+++ b/src/web/src/modules/centre/components/DataEntry.vue
@@ -13,12 +13,10 @@
   </div>
 
   <template v-if="entryMode">
-    IncrementalDataEntryCard
-    <IncrementalDataEntryCard />
+    <BulkDataEntryCard />
   </template>
   <template v-else>
-    BulkDataEntryCard
-    <BulkDataEntryCard />
+    <IncrementalDataEntryCard />
   </template>
 </template>
 
@@ -34,7 +32,7 @@ export default {
   },
   data () {
     return {
-      entryMode: false,
+      entryMode: true,
     }
   },
 }

--- a/src/web/src/modules/centre/components/DataEntry.vue
+++ b/src/web/src/modules/centre/components/DataEntry.vue
@@ -13,7 +13,9 @@
   </div>
 
   <template v-if="entryMode">
-    <BulkDataEntryCard />
+    <BulkDataEntryCard
+      @save="entryMode = false"
+    />
   </template>
   <template v-else>
     <IncrementalDataEntryCard />

--- a/src/web/src/modules/centre/components/DataEntry.vue
+++ b/src/web/src/modules/centre/components/DataEntry.vue
@@ -34,7 +34,7 @@ export default {
   },
   data () {
     return {
-      entryMode: true,
+      entryMode: false,
     }
   },
 }

--- a/src/web/src/modules/centre/components/IncrementalDataEntryCard.vue
+++ b/src/web/src/modules/centre/components/IncrementalDataEntryCard.vue
@@ -1,0 +1,186 @@
+<template>
+  <BaseCard showHeader="t" heading="" class="pb-3">
+    <template v-slot:left>
+      <v-select
+        :items="manageSites"
+        label="Site"
+        hide-details
+        v-model="selectedSite"
+        return-object
+        style="max-width: 250px"
+        item-title="name"
+        :disabled="isDirty"
+        @update:modelValue="changed"
+        item-value="id"></v-select>
+    </template>
+
+    <template v-slot:center>
+      <div style="margin-top: 0px; text-align: center">
+        <div style="font-size: 1.5rem; font-weight: bold; line-height: 1.6rem">{{ totalCountHeader }}</div>
+        {{ dateHeader }}
+      </div>
+    </template>
+
+    <template v-slot:right>
+      <v-select
+        v-model="selectedDate"
+        label="Date"
+        :items="dateOptions"
+        item-title="date"
+        return-object
+        hide-details
+        :disabled="isDirty"
+        style="max-width: 250px"></v-select>
+    </template>
+
+    <div v-if="selectedSite">
+      <v-row class="mt-5">
+        <v-col cols="3">Visitor Origin</v-col>
+        <v-col></v-col>
+        <v-col cols="3" class="text-body-1 text-center"> Daily Totals </v-col>
+        <!-- <v-col cols="3" class="text-body-1 text-center"> Weekly Totals </v-col> -->
+      </v-row>
+      <v-row v-for="(location, idx) of selectedDate.origins" :key="idx">
+        <v-divider></v-divider>
+        <v-col cols="3">
+          <div class="text-h6 float-left pt-3">{{ location.name }}</div>
+        </v-col>
+        <v-col>
+          <div class="text-center">
+            <v-btn variant="flat" color="#3A8340" icon="" class="mr-3" @click="plusOne(location)"
+              ><span style="color: white">+1</span></v-btn
+            >
+            <v-btn variant="flat" color="#3A8340" icon="" class="mr-10" @click="plusFive(location)"
+              ><span style="color: white">+5</span></v-btn
+            >
+            <v-btn
+              variant="flat"
+              color="orange"
+              icon=""
+              class="mr-3"
+              @click="minusOne(location)"
+              :disabled="location.daily_total - 1 < 0"
+              >-1</v-btn
+            >
+            <v-btn
+              variant="flat"
+              color="orange"
+              icon=""
+              class="mr-0"
+              @click="minusFive(location)"
+              :disabled="location.daily_total - 5 < 0"
+              >-5</v-btn
+            >
+          </div>
+        </v-col>
+
+        <v-col cols="3" class="text-h6 text-center pt-3">
+          <div class="pt-3">{{ location.daily_total }}</div>
+        </v-col>
+        <!-- <v-col cols="3" class="text-h6 text-center pt-3">
+          <div class="pt-3">{{ location.weekly_total }}</div>
+        </v-col> -->
+      </v-row>
+    </div>
+    <div v-else>Not site selected</div>
+  </BaseCard>
+</template>
+
+<script lang="ts">
+import { mapActions, mapState, mapWritableState } from "pinia";
+import moment from "moment";
+import { useUserStore } from "@/store/UserStore";
+import { useCentreStore } from "../store";
+
+export default {
+  name: "IncrementalDataEntryCard",
+  components: {},
+  data: () => ({
+    total: 0,
+    isDirty: false,
+  }),
+  async mounted() {
+    //if (this.user.primary_site && this.user.primary_site != -1) this.site = this.user.primary_site;
+    let r = window.setInterval(async () => {
+      if (!this.isDirty) return;
+
+      await this.save();
+      this.isDirty = false;
+    }, 2000);
+
+    if (this.loadFor.length > 0) {
+      await this.loadDailyStats(this.loadFor);
+      this.selectFirstToManage();
+    }
+  },
+  async beforeUnmount() {
+    if (this.selectedDate && this.isDirty) {
+      await this.save();
+    }
+  },
+  computed: {
+    ...mapState(useUserStore, ["user"]),
+    ...mapState(useCentreStore, ["dateOptions", "manageSites"]),
+    ...mapWritableState(useCentreStore, ["selectedDate", "selectedSite"]),
+
+    loadFor() {
+      return this.user.scopes
+        .filter((s: any) => s.name.startsWith("VIC.INPUT"))
+        .map((s: any) => parseInt(s.name.replace("VIC.INPUT_", "")));
+    },
+    totalCountHeader() {
+      if (this.selectedDate && this.selectedDate.origins) {
+        let counts = this.selectedDate.origins.flatMap((i: any) => i.daily_total);
+        let total = counts.reduce((t: number, i: any) => t + i, 0);
+        return `${total} visitors`;
+      }
+      return "";
+    },
+    dateHeader() {
+      if (this.selectedSite && this.selectedDate) {
+        return `${moment(this.selectedDate.date).format("MMMM D, YYYY")} in ${this.selectedSite.name}`;
+      }
+
+      return "";
+    },
+  },
+  methods: {
+    ...mapActions(useUserStore, ["canDo"]),
+    ...mapActions(useCentreStore, ["save", "loadDailyStats", "selectFirstToManage"]),
+
+    changed() {
+      this.selectedDate = (this.selectedSite as any).days[0];
+    },
+
+    plusOne(location: any) {
+      this.isDirty = true;
+      location.delta++;
+    },
+    plusFive(location: any) {
+      this.isDirty = true;
+      location.delta += 5;
+    },
+    minusOne(location: any) {
+      this.isDirty = true;
+      location.delta--;
+    },
+    minusFive(location: any) {
+      this.isDirty = true;
+      location.delta -= 5;
+    },
+  },
+};
+</script>
+
+<style>
+.v-btn.v-btn--disabled.bg-orange {
+  background-color: #895200 !important;
+}
+.v-btn.v-btn--disabled.bg-orange .v-btn__overlay {
+  opacity: 0;
+}
+
+.v-btn.v-btn--disabled.bg-orange .v-btn__content {
+  color: white !important;
+}
+</style>

--- a/src/web/src/modules/centre/store/index.ts
+++ b/src/web/src/modules/centre/store/index.ts
@@ -52,7 +52,7 @@ export const useCentreStore = defineStore("centre", {
     async save() {
       const api = useApiStore();
 
-      api
+      return api
         .secureCall("put", `${VISITORCENTRE_URL}/record-stats`, {
           date: this.selectedDate,
           site: this.selectedSite,
@@ -70,9 +70,11 @@ export const useCentreStore = defineStore("centre", {
               this.manageSites.splice(index, 1, this.selectedSite);
             }
           }
-        });
 
-      m.notify({ variant: "success", text: "Saved" });
+          m.notify({ variant: "success", text: "Saved" });
+
+          return this.selectedSite
+        });
     },
 
     add(originName: string, date: string, amount: number) {


### PR DESCRIPTION
# Overview

Some visitor centres use door counters, and at the end of the day, get an overall number of visitors, rather than doing input incrementally. They want to first enter the overall total, then distribute the visitors into various categories base on -- I'm guessing -- paper records that they have been keeping through the day. They need to see the difference (unallocated) to know they got the middle numbers correct.

- Fixes #1

# Implementation

Bulk edit mode makes use of the existing API endpoint by setting the appropriate "delta" for the given location. I opted not to clear the database values, and instead make use of the existing architecture for better traceability and reversibility.

Visitors of "Unknown" origin can never be set directly, only as a result of setting the "total" visitors, and having uncategorized visitors left over. This vastly reduces complexity and enhances data integrity.

I've used heavy JS validation to prevent the user from entering invalid input, but this validation is silent. This validation is all on the front-end, and does not include and form validation warnings. Invalid data simply does not persist in the UI.

When a User reduces the number of total visitors, this wipes all visitor category totals, and moves all values back to the "unknown" category. An alternative solution would be to lock edit of the "Total visitors" field if any data exists in any of the other fields; however, this seems like it would have the same effect, and be much more work for the User.

# Questions/Concerns
- [ ] Should I duplicate/refactor the `/record-stats` endpoint such that full replace is possible? This vastly increases complexity, with uncertain benefit.
- [ ] Should I share the data entry card header between the two edit modes? This vastly increases complexity, but would result in shared visitor centre and date values. Currently implementation resets when "edit" mode is toggled.
- [ ] The validation logic is pretty complicated, and completely untested. Is it worth configuring a test suite just for this feature?
- [ ] Should I wrap the build edit mode feature in a "form" tag and use form validation errors for accessibility reasons?

# Test Instructions

1. Boot the database via `docker compose --env-file ./.env.development --file docker-compose.dev.yaml up --build`
2. Boot the API back-end via `cd src/api && npm run start`
3. Boot the Vue front-end via `cd src/web && npm run start`
4. Log in using your "Government of Yukon online services account" to http://localhost:8080
5. Open your database editor and connect to the database with the credential from your `db/sapassword.env` file.
e.g.
```
user => sa
password => DifficultPassword123!
```
6. Make your user an admin by going to the `user#is_admin` -> `1` via your database editor.
7. Go back to the app at http://localhost:8080, and log out and log back.
8. Go to the Administraion section of the top right kebab menu.
![image](https://github.com/icefoganalytics/tourism-activity-statistics-tracking/assets/23045206/18ee32d5-3af5-491d-a2b0-bf90c1b2ecb2)
9. Click "Users".
10. Click your user to edit it.
11. Add permissions for all sites.
12. Add all sites to "sites to manage".
13. Click save.
14. Click home, or go to http://localhost:8080/dashboard.
15. Select a Visitor center and a date.
16. Click to toggle the "Bulk Input" mode.
> Note that this currently resets the select visitor centre and date, this should probably get fixed? This could be fixed a number of ways, the simplest being moving the load/select visitor centre date to a "created" instead of a "mounted" hook, though that might create other problems.
17. Enter a daily visitor total such as `100`.
18. Note that the number of "Unknown" visitors increase by the same amount.
19. Enter some visitors in the various columns.
20. Note that you cannot overflow the max daily total visitors.
21. Note that the "Unknown" visitors value decreases as you distribute amounts to other locations.
22. Click save.
23. You will be redirected back to the "incremental" data entry mode with the new values present.
24. Switch back to "bulk" entry mode, note that the values carry back over.
25. Reduce the number of total visitors. Note that this wipes all visitors totals and moves all values back to the "unknown" category.
26. Click "save" again and check that the values persist.

